### PR TITLE
amdxdna: add VE2 auxiliary driver probe and device init

### DIFF
--- a/drivers/accel/amdxdna/amdxdna_aux_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_aux_drv.c
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2022-2026, Advanced Micro Devices, Inc.
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ *
+ * Auxiliary-bus attachment for AMD XDNA / AIE-backed devices. This file is
+ * backend-agnostic: each auxiliary_device_id entry binds a firmware-visible
+ * auxiliary name to a const struct amdxdna_dev_info (via .driver_data).
+ * Add a row (and matching dev_info / ops in a veN_aux.c) when a new aux
+ * hardware generation is supported.
  */
 
 #include <drm/drm_drv.h>
@@ -12,21 +18,18 @@
 #include "amdxdna_drv.h"
 #include "ve2_aux.h"
 
-const struct amdxdna_dev_info dev_ve2_info = {
-	.device_type	= 0,
-	.dev_priv	= NULL,
-	.ops		= &ve2_ops,
-};
-
-static const struct auxiliary_device_id amdxdna_ve2_aux_id_table[] = {
-	{ .name = "xilinx_aie.amdxdna" },
+static const struct auxiliary_device_id amdxdna_aux_id_table[] = {
+	{
+		.name = "xilinx_aie.amdxdna",
+		.driver_data = (kernel_ulong_t)&dev_ve2_info,
+	},
 	{}
 };
 
-MODULE_DEVICE_TABLE(auxiliary, amdxdna_ve2_aux_id_table);
+MODULE_DEVICE_TABLE(auxiliary, amdxdna_aux_id_table);
 
-static int amdxdna_ve2_aux_probe(struct auxiliary_device *auxdev,
-				 const struct auxiliary_device_id *id)
+static int amdxdna_aux_probe(struct auxiliary_device *auxdev,
+			     const struct auxiliary_device_id *id)
 {
 	struct device *dev = &auxdev->dev;
 	struct amdxdna_dev *xdna;
@@ -36,15 +39,13 @@ static int amdxdna_ve2_aux_probe(struct auxiliary_device *auxdev,
 	if (IS_ERR(xdna))
 		return PTR_ERR(xdna);
 
-	xdna->dev_info = &dev_ve2_info;
-	if (!xdna->dev_info)
-		return -ENODEV;
+	xdna->dev_info = (const struct amdxdna_dev_info *)id->driver_data;
+	if (!xdna->dev_info || !xdna->dev_info->ops) {
+		XDNA_WARN(xdna, "No matching aux device found");
+		return -EINVAL;
+	}
 
 	auxiliary_set_drvdata(auxdev, xdna);
-
-	ret = amdxdna_dev_init(xdna);
-	if (ret)
-		return ret;
 
 	if (!dev->dma_mask) {
 		dev->coherent_dma_mask = DMA_BIT_MASK(64);
@@ -55,33 +56,35 @@ static int amdxdna_ve2_aux_probe(struct auxiliary_device *auxdev,
 		ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32));
 		if (ret) {
 			XDNA_ERR(xdna, "DMA mask set failed (64 and 32 bit), ret %d", ret);
-			goto failed_dev_cleanup;
+			return ret;
 		}
-		XDNA_WARN(xdna, "DMA configuration downgraded to 32bit Mask\n");
+		XDNA_WARN(xdna, "DMA configuration downgraded to 32bit mask");
+	}
+
+	ret = amdxdna_dev_init(xdna);
+	if (ret) {
+		XDNA_ERR(xdna, "amdxdna dev init failed with ret %d", ret);
+		return ret;
 	}
 
 	return 0;
-
-failed_dev_cleanup:
-	amdxdna_dev_cleanup(xdna);
-	return ret;
 }
 
-static void amdxdna_ve2_aux_remove(struct auxiliary_device *auxdev)
+static void amdxdna_aux_remove(struct auxiliary_device *auxdev)
 {
 	struct amdxdna_dev *xdna = auxiliary_get_drvdata(auxdev);
 
 	amdxdna_dev_cleanup(xdna);
 }
 
-static struct auxiliary_driver amdxdna_ve2_aux_driver = {
-	.name		= "amdxdna",
-	.probe		= amdxdna_ve2_aux_probe,
-	.remove		= amdxdna_ve2_aux_remove,
-	.id_table	= amdxdna_ve2_aux_id_table,
+static struct auxiliary_driver amdxdna_aux_driver = {
+	.name		= KBUILD_MODNAME,
+	.probe		= amdxdna_aux_probe,
+	.remove		= amdxdna_aux_remove,
+	.id_table	= amdxdna_aux_id_table,
 };
 
-module_auxiliary_driver(amdxdna_ve2_aux_driver);
+module_auxiliary_driver(amdxdna_aux_driver);
 
 MODULE_LICENSE(AMDXDNA_MODULE_LICENSE);
 MODULE_AUTHOR(AMDXDNA_MODULE_AUTHOR);

--- a/drivers/accel/amdxdna/amdxdna_pci_drv.c
+++ b/drivers/accel/amdxdna/amdxdna_pci_drv.c
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright (C) 2022-2026, Advanced Micro Devices, Inc.
+ *
+ * PCI attachment for AMD XDNA devices. Board identity comes from the PCI id
+ * table: each entry's .driver_data points at a null-terminated table of
+ * (revision, dev_info) rows so one PCI device ID can map to several NPU
+ * profiles (e.g. 0x17f0 revisions -> NPU4/5/6). Add a new pci_device_id row
+ * and revision map when a new PCI device is supported; keep AIE2/AIE4
+ * implementation in aie2_pci.c / aie4_pci.c and npu*_regs.c.
  */
 
 #include "drm/amdxdna_accel.h"
@@ -32,41 +39,61 @@ MODULE_FIRMWARE("amdnpu/1502_00/npu_7.sbin");
 MODULE_FIRMWARE("amdnpu/17f0_10/npu_7.sbin");
 MODULE_FIRMWARE("amdnpu/17f0_11/npu_7.sbin");
 
-/*
- * Bind the driver base on (vendor_id, device_id) pair and later use the
- * (device_id, rev_id) pair as a key to select the devices. The devices with
- * same device_id have very similar interface to host driver.
+/**
+ * struct amdxdna_pci_rev_map - Map PCI revision to &struct amdxdna_dev_info.
+ * Tables are null-terminated with an entry where %dev_info is NULL.
  */
+struct amdxdna_pci_rev_map {
+	u8 revision;
+	const struct amdxdna_dev_info *dev_info;
+};
+
+static const struct amdxdna_pci_rev_map amdxdna_pci_1502[] = {
+	{ 0x00, &dev_npu1_info },
+	{ }
+};
+
+static const struct amdxdna_pci_rev_map amdxdna_pci_17f0[] = {
+	{ 0x10, &dev_npu4_info },
+	{ 0x11, &dev_npu5_info },
+	{ 0x20, &dev_npu6_info },
+	{ }
+};
+
+static const struct amdxdna_pci_rev_map amdxdna_pci_17f2[] = {
+	{ 0x10, &dev_npu3_pf_info },
+	{ }
+};
+
+static const struct amdxdna_pci_rev_map amdxdna_pci_1b0b[] = {
+	{ 0x10, &dev_npu3_pf_info },
+	{ }
+};
+
 static const struct pci_device_id pci_ids[] = {
-	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, 0x1502) },
-	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, 0x17f0) },
-	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, 0x17f2) },
-	{ PCI_DEVICE(PCI_VENDOR_ID_AMD, 0x1B0B) },
-	{0}
+	{ PCI_VDEVICE(AMD, 0x1502), .driver_data = (kernel_ulong_t)amdxdna_pci_1502 },
+	{ PCI_VDEVICE(AMD, 0x17f0), .driver_data = (kernel_ulong_t)amdxdna_pci_17f0 },
+	{ PCI_VDEVICE(AMD, 0x17f2), .driver_data = (kernel_ulong_t)amdxdna_pci_17f2 },
+	{ PCI_VDEVICE(AMD, 0x1b0b), .driver_data = (kernel_ulong_t)amdxdna_pci_1b0b },
+	{ }
 };
 
 MODULE_DEVICE_TABLE(pci, pci_ids);
 
-static const struct amdxdna_device_id amdxdna_ids[] = {
-	{ 0x1502, 0x0,  &dev_npu1_info },
-	{ 0x17f0, 0x10, &dev_npu4_info },
-	{ 0x17f0, 0x11, &dev_npu5_info },
-	{ 0x17f0, 0x20, &dev_npu6_info },
-	{ 0x17f2, 0x10, &dev_npu3_pf_info },
-	{ 0x1B0B, 0x10, &dev_npu3_pf_info },
-	{0}
-};
-
 static const struct amdxdna_dev_info *
-amdxdna_get_dev_info(struct pci_dev *pdev)
+amdxdna_pci_match_dev_info(struct pci_dev *pdev, const struct pci_device_id *id)
 {
-	int i;
+	const struct amdxdna_pci_rev_map *row =
+		(const struct amdxdna_pci_rev_map *)id->driver_data;
 
-	for (i = 0; i < ARRAY_SIZE(amdxdna_ids); i++) {
-		if (pdev->device == amdxdna_ids[i].device &&
-		    pdev->revision == amdxdna_ids[i].revision)
-			return amdxdna_ids[i].dev_info;
+	if (!row)
+		return NULL;
+
+	for (; row->dev_info; row++) {
+		if (pdev->revision == row->revision)
+			return row->dev_info;
 	}
+
 	return NULL;
 }
 
@@ -80,8 +107,8 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (IS_ERR(xdna))
 		return PTR_ERR(xdna);
 
-	xdna->dev_info = amdxdna_get_dev_info(pdev);
-	if (!xdna->dev_info)
+	xdna->dev_info = amdxdna_pci_match_dev_info(pdev, id);
+	if (!xdna->dev_info || !xdna->dev_info->ops)
 		return -ENODEV;
 
 	pci_set_drvdata(pdev, xdna);
@@ -98,7 +125,7 @@ static int amdxdna_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 		fs_reclaim_release(GFP_KERNEL);
 	}
 
-	xdna->notifier_wq = alloc_ordered_workqueue("notifier_wq", WQ_MEM_RECLAIM);
+	xdna->notifier_wq = alloc_ordered_workqueue("amdxdna_pci_notifier", WQ_MEM_RECLAIM);
 	if (!xdna->notifier_wq) {
 		ret = -ENOMEM;
 		goto failed_iommu_fini;

--- a/drivers/accel/amdxdna/ve2_aux.c
+++ b/drivers/accel/amdxdna/ve2_aux.c
@@ -1,34 +1,217 @@
 // SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
  */
 
-#include <linux/errno.h>
+#include "drm/amdxdna_accel.h"
+#include <linux/firmware.h>
+#include <linux/slab.h>
+#include <linux/string.h>
 
-#include "amdxdna_drv.h"
+#include "amdxdna_ctx.h"
 #include "ve2_aux.h"
 
-struct amdxdna_hwctx;
-struct amdxdna_sched_job;
-struct amdxdna_gem_obj;
+/* Declares firmware for modinfo/packaging. Loaded at runtime via request_firmware() in ve2_load_fw(). */
+MODULE_FIRMWARE("amdnpu/release_cert_ve2.elf");
+
+static const struct ve2_aux_dev_priv ve2_aux_priv = {
+	.fw_path	= "amdnpu/release_cert_ve2.elf",
+};
+
+/*
+ * Cast: common code keeps dev_priv as const struct amdxdna_dev_priv *; VE2
+ * only reads fw_path and limits, which match the leading logical fields.
+ */
+const struct amdxdna_dev_info dev_ve2_info = {
+	.device_type	= AMDXDNA_DEV_TYPE_KMQ,
+	.dev_priv	= (const struct amdxdna_dev_priv *)&ve2_aux_priv,
+	.ops		= &ve2_ops,
+};
+
+static int ve2_partition_read_wrap(struct device *aie_dev, u32 col, u32 row,
+				   u32 offset, size_t size, void *buf)
+{
+	struct aie_location loc = { .col = col, .row = row };
+
+	return aie_partition_read(aie_dev, loc, offset, size, buf);
+}
+
+static int ve2_store_firmware_version(struct ve2_firmware_version *c_version,
+				      struct device *xaie_dev)
+{
+	struct ve2_firmware_version *version;
+	int ret;
+
+	version = kzalloc(sizeof(*version), GFP_KERNEL);
+	if (!version)
+		return -ENOMEM;
+
+	ret = ve2_partition_read_wrap(xaie_dev, 0, 0,
+				    VE2_PROG_DATA_MEMORY_OFF + VE2_CERT_VERSION_OFF,
+				    VE2_CERT_VERSION_SIZE, version);
+	if (ret < 0) {
+		kfree(version);
+		return ret;
+	}
+
+	c_version->major = version->major;
+	c_version->minor = version->minor;
+	strscpy(c_version->git_hash, version->git_hash, VE2_FW_HASH_STRING_LENGTH);
+	strscpy(c_version->date, version->date, VE2_FW_DATE_STRING_LENGTH);
+	c_version->hotfix = version->hotfix;
+	c_version->build = version->build;
+	kfree(version);
+
+	return 0;
+}
+
+static int ve2_partition_initialize_wrap(struct device *dev, struct aie_partition_init_args *args)
+{
+	return aie_partition_initialize(dev, args);
+}
+
+static int ve2_load_fw(struct amdxdna_dev_hdl *xdna_hdl)
+{
+	struct amdxdna_dev *xdna = xdna_hdl->xdna;
+	struct aie_partition_init_args args;
+	struct aie_partition_req request;
+	const struct firmware *fw;
+	struct device *xaie_dev;
+	char *buf;
+	int ret;
+
+	XDNA_DBG(xdna, "Loading firmware: %s", xdna_hdl->ve2_priv->fw_path);
+
+	ret = request_firmware(&fw, xdna_hdl->ve2_priv->fw_path, xdna->ddev.dev);
+	if (ret) {
+		XDNA_ERR(xdna, "request fw %s failed %d", xdna_hdl->ve2_priv->fw_path, ret);
+		return -ENODEV;
+	}
+
+	buf = kmalloc(fw->size, GFP_KERNEL);
+	if (!buf) {
+		release_firmware(fw);
+		return -ENOMEM;
+	}
+	memcpy(buf, fw->data, fw->size);
+	release_firmware(fw);
+
+	xaie_dev = aie_partition_request(&request);
+	if (IS_ERR(xaie_dev)) {
+		ret = PTR_ERR(xaie_dev);
+		XDNA_ERR(xdna, "aie partition request failed: %d", ret);
+		goto out;
+	}
+	XDNA_DBG(xdna, "aie partition request succeeded: 0x%x", request.partition_id);
+
+	args.locs = NULL;
+	args.num_tiles = 0;
+	args.handshake_cols = 0;
+	args.handshake = NULL;
+	args.init_opts = (AIE_PART_INIT_OPT_DEFAULT | AIE_PART_INIT_OPT_DIS_TLAST_ERROR) &
+			 ~AIE_PART_INIT_OPT_UC_ENB_MEM_PRIV;
+	ret = ve2_partition_initialize_wrap(xaie_dev, &args);
+	if (ret) {
+		XDNA_ERR(xdna, "aie partition init failed: %d", ret);
+		goto release;
+	}
+
+	ret = aie_load_cert_broadcast(xaie_dev, buf);
+	if (ret) {
+		XDNA_ERR(xdna, "aie load cert broadcast failed %d", ret);
+		goto teardown;
+	}
+	XDNA_INFO(xdna, "aie load cert broadcast complete");
+
+	ret = ve2_store_firmware_version(&xdna_hdl->fw_version, xaie_dev);
+	if (ret < 0) {
+		XDNA_ERR(xdna, "cert status read failed with err %d", ret);
+		goto teardown;
+	}
+	XDNA_INFO(xdna, "CERT major: %d", xdna_hdl->fw_version.major);
+	XDNA_INFO(xdna, "CERT minor: %d", xdna_hdl->fw_version.minor);
+
+teardown:
+	aie_partition_teardown(xaie_dev);
+release:
+	aie_partition_release(xaie_dev);
+out:
+	kfree(buf);
+	return ret;
+}
 
 static int ve2_init(struct amdxdna_dev *xdna)
 {
-	return -EOPNOTSUPP;
+	struct ve2_firmware_status *fw_slots;
+	struct device *dev = xdna->ddev.dev;
+	struct amdxdna_dev_hdl *xdna_hdl;
+	int ret;
+	u32 col;
+
+	XDNA_DBG(xdna, "Initializing VE2 device");
+
+	xdna_hdl = devm_kzalloc(dev, sizeof(*xdna_hdl), GFP_KERNEL);
+	if (!xdna_hdl)
+		return -ENOMEM;
+
+	xdna_hdl->xdna = xdna;
+	xdna_hdl->ve2_priv = &ve2_aux_priv;
+	xdna->dev_handle = xdna_hdl;
+
+	ret = aie_get_device_info(&xdna_hdl->aie_dev_info);
+	if (ret) {
+		if (ret == -ENODEV) {
+			XDNA_INFO(xdna, "AIE device not ready yet, deferring probe");
+			return -EPROBE_DEFER;
+		}
+		XDNA_ERR(xdna, "Failed to get AIE device info, ret %d", ret);
+		return ret;
+	}
+	XDNA_INFO(xdna, "AIE device: %d columns, %d rows",
+		  xdna_hdl->aie_dev_info.cols, xdna_hdl->aie_dev_info.rows);
+
+	ret = ve2_load_fw(xdna_hdl);
+	if (ret) {
+		XDNA_ERR(xdna, "aie load %s failed with err %d", xdna_hdl->ve2_priv->fw_path, ret);
+		return ret;
+	}
+	XDNA_DBG(xdna, "aie fw load %s completed", xdna_hdl->ve2_priv->fw_path);
+
+	xdna_hdl->fw_slots = devm_kcalloc(dev, xdna_hdl->aie_dev_info.cols,
+					  sizeof(*xdna_hdl->fw_slots), GFP_KERNEL);
+	if (!xdna_hdl->fw_slots) {
+		XDNA_ERR(xdna, "No memory for fw_slots array");
+		return -ENOMEM;
+	}
+
+	for (col = 0; col < xdna_hdl->aie_dev_info.cols; col++) {
+		fw_slots = devm_kzalloc(dev, sizeof(*fw_slots), GFP_KERNEL);
+		if (!fw_slots) {
+			XDNA_ERR(xdna, "No memory for fw status");
+			return -ENOMEM;
+		}
+		xdna_hdl->fw_slots[col] = fw_slots;
+	}
+
+	return 0;
 }
 
 static void ve2_fini(struct amdxdna_dev *xdna)
 {
+	struct amdxdna_dev_hdl *hdl = ve2_dev_hdl(xdna);
+
+	if (!hdl)
+		return;
+
+	XDNA_DBG(xdna, "VE2 device cleanup");
 }
 
-static int ve2_get_aie_info(struct amdxdna_client *client,
-			    struct amdxdna_drm_get_info *args)
+static int ve2_get_aie_info(struct amdxdna_client *client, struct amdxdna_drm_get_info *args)
 {
 	return -EOPNOTSUPP;
 }
 
-static int ve2_set_aie_state(struct amdxdna_client *client,
-			     struct amdxdna_drm_set_state *args)
+static int ve2_set_aie_state(struct amdxdna_client *client, struct amdxdna_drm_set_state *args)
 {
 	return -EOPNOTSUPP;
 }
@@ -61,8 +244,7 @@ static int ve2_cmd_submit(struct amdxdna_hwctx *hwctx, struct amdxdna_sched_job 
 	return -EOPNOTSUPP;
 }
 
-static int ve2_get_array(struct amdxdna_client *client,
-			 struct amdxdna_drm_get_array *args)
+static int ve2_get_array(struct amdxdna_client *client, struct amdxdna_drm_get_array *args)
 {
 	return -EOPNOTSUPP;
 }

--- a/drivers/accel/amdxdna/ve2_aux.h
+++ b/drivers/accel/amdxdna/ve2_aux.h
@@ -1,15 +1,104 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
- * Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
+ * Copyright (C) 2026, Advanced Micro Devices, Inc.
+ *
+ * VE2 auxiliary backend. struct amdxdna_dev_hdl below is VE2-specific; do not
+ * include aie2_pci.h in the same translation unit (different dev_hdl layout).
  */
 
 #ifndef _VE2_AUX_H_
 #define _VE2_AUX_H_
 
+#include <linux/device.h>
+#include <linux/mutex.h>
+#include <linux/types.h>
+#include <linux/workqueue.h>
+
+#include <linux/xlnx-ai-engine.h>
+
 #include "amdxdna_drv.h"
 
 struct amdxdna_dev_priv;
+#define VE2_MAX_MEM_REGIONS		8
 
+#define VE2_PROG_DATA_MEMORY_OFF	0x80000
+#define VE2_CERT_VERSION_OFF		0x50
+#define VE2_CERT_VERSION_SIZE		0x40
+
+#define VE2_FW_HASH_STRING_LENGTH	41
+#define VE2_FW_DATE_STRING_LENGTH	11
+
+struct ve2_firmware_version {
+	u8 major;
+	u8 minor;
+	char git_hash[VE2_FW_HASH_STRING_LENGTH];
+	char date[VE2_FW_DATE_STRING_LENGTH];
+	u8 hotfix;
+	u8 build;
+};
+
+struct ve2_firmware_status {
+	u32 state;
+	u32 abs_page_index;
+	u32 ppc;
+	u32 idle_status;
+	u32 misc_status;
+};
+
+struct ve2_mem_region {
+	u32 start_col;
+	u32 end_col;
+	u32 mem_bitmap;
+};
+
+struct ve2_mem_topology {
+	u32 num_regions;
+	struct ve2_mem_region regions[VE2_MAX_MEM_REGIONS];
+};
+
+struct ve2_aux_dev_priv {
+	const char *fw_path;
+	u32 hwctx_limit;
+	u32 ctx_limit;
+};
+
+struct amdxdna_dev;
+
+struct ve2_mgmtctx {
+	struct amdxdna_dev		*xdna;
+	void				*active_ctx;
+	struct device			*mgmt_aiedev;
+	u32				start_col;
+	u32				mgmt_partid;
+	struct aie_partition_init_args	args;
+	struct list_head		ctx_command_fifo_head;
+	struct mutex			ctx_lock;
+	struct work_struct		sched_work;
+	struct workqueue_struct		*mgmtctx_workq;
+	u32				is_partition_idle;
+	u32				is_context_req;
+	u32				is_idle_due_to_context;
+};
+
+struct amdxdna_dev_hdl {
+	struct amdxdna_dev			*xdna;
+	const struct ve2_aux_dev_priv		*ve2_priv;
+	u32					hwctx_limit;
+	u32					hwctx_cnt;
+	struct ve2_firmware_version		fw_version;
+	struct aie_device_info			aie_dev_info;
+	struct ve2_firmware_status		**fw_slots;
+	struct ve2_mgmtctx			*ve2_mgmtctx;
+	struct ve2_mem_topology			mem_topology;
+	struct device				*cma_region_devs[VE2_MAX_MEM_REGIONS];
+};
+
+extern const struct amdxdna_dev_info dev_ve2_info;
 extern const struct amdxdna_dev_ops ve2_ops;
+
+static inline struct amdxdna_dev_hdl *ve2_dev_hdl(struct amdxdna_dev *xdna)
+{
+	return xdna->dev_handle;
+}
 
 #endif /* _VE2_AUX_H_ */


### PR DESCRIPTION
1) Add amdxdna_aux_drv.c as the auxiliary_bus glue: DMA mask and amdxdna_dev_init ordering aligned with PCI.
2) Implement ve2_init/fini in ve2_aux.c from the out-of-tree VE2 path: device handle, AIE topology via aie_get_device_info(), firmware load and cert broadcast, per-column fw_slots.
3) Keep dev_ve2_info and ve2_aux_priv next to ve2_ops in ve2_aux.c 
4) Define VE2-specific struct amdxdna_dev_hdl in ve2_aux.h 
5) select PCI dev_info from pci_device_id driver_data rev maps: Refactor amdxdna_pci_drv.c so board selection matches the auxiliary driver pattern, each pci_device_id uses .driver_data to point at a null-terminated array of (revision, dev_info) entries instead of a separate amdxdna_ids[] table and amdxdna_get_dev_info().